### PR TITLE
Feature/ios lib

### DIFF
--- a/lib/ios/README.md
+++ b/lib/ios/README.md
@@ -1,0 +1,1 @@
+Instructions to compile: https://github.com/null09264/ZBarSDK-for-iOS


### PR DESCRIPTION
The ios libzbar.a is a Mach-O universal library.

```bash
$ file libzbar.a
libzbar.a: Mach-O universal binary with 4 architectures: [arm_v7:current ar archive] [i386] [x86_64] [arm64]
libzbar.a (for architecture armv7):	current ar archive
libzbar.a (for architecture i386):	current ar archive
libzbar.a (for architecture x86_64):	current ar archive
libzbar.a (for architecture arm64):	current ar archive
```